### PR TITLE
feat(typescript): use React.Key type

### DIFF
--- a/dist/ReactKeyGen.d.ts
+++ b/dist/ReactKeyGen.d.ts
@@ -1,10 +1,10 @@
-type Primitive = string | number | boolean | null | undefined;
+import type { Key } from 'react';
 declare class ReactKeyGen {
     #private;
     constructor({ keyBaseName, primitiveToKey }?: {
         keyBaseName?: string | undefined;
-        primitiveToKey?: ((value: Primitive) => Primitive) | undefined;
+        primitiveToKey?: ((value: unknown) => Key | null | undefined) | undefined;
     });
-    getKey(value: unknown): Primitive;
+    getKey(value: unknown): Key | null | undefined;
 }
 export default ReactKeyGen;

--- a/dist/ReactKeyGen.js
+++ b/dist/ReactKeyGen.js
@@ -1,7 +1,18 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const isPrimitive = (value) => !value || !['object', 'function'].includes(typeof value);
-const defaultPrimitiveToKey = (value) => value?.toString ? value.toString() : value;
+const defaultPrimitiveToKey = (value) => {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (typeof value.toString === 'function') {
+        return value.toString();
+    }
+    return String(value);
+};
 class ReactKeyGen {
     #keysMap = new WeakMap();
     #keyBaseName;

--- a/src/ReactKeyGen.ts
+++ b/src/ReactKeyGen.ts
@@ -1,15 +1,28 @@
-type Primitive = string | number | boolean | null | undefined;
+import type { Key } from 'react';
 
 const isPrimitive = (value: unknown): boolean =>
   !value || !['object', 'function'].includes(typeof value);
 
-const defaultPrimitiveToKey = (value: Primitive): Primitive =>
-  value?.toString ? value.toString() : value;
+const defaultPrimitiveToKey = (value: unknown): Key | null | undefined => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof (value as { toString: () => string }).toString === 'function') {
+    return value.toString();
+  }
+
+  return String(value);
+};
 
 class ReactKeyGen {
   #keysMap = new WeakMap<object, string>();
   #keyBaseName: string;
-  #primitiveToKey: (value: Primitive) => Primitive;
+  #primitiveToKey: (value: unknown) => Key | null | undefined;
   #cpt = -1;
 
   constructor({ keyBaseName = 'keyGen_', primitiveToKey = defaultPrimitiveToKey } = {}) {
@@ -22,9 +35,9 @@ class ReactKeyGen {
     return `${this.#keyBaseName}${this.#cpt}`;
   }
 
-  getKey(value: unknown): Primitive {
+  getKey(value: unknown): Key | null | undefined {
     if (isPrimitive(value)) {
-      return this.#primitiveToKey(value as Primitive);
+      return this.#primitiveToKey(value);
     }
 
     if (typeof value === 'object' && value !== null) {
@@ -39,7 +52,7 @@ class ReactKeyGen {
       return newKey;
     }
 
-    return this.#primitiveToKey(value as Primitive);
+    return this.#primitiveToKey(value);
   }
 }
 


### PR DESCRIPTION
Returns a proper `ReactKeyGen.getKey(value: unknown): React.Key | null | undefined`. 
No more TypeScript error when using your lib in a `.tsx` file.

```javascriptreact
<div className="header-steps">
  {steps.map((step, index) => (
    <button
      disabled={
        (index > confStep && !confValidated[confStep]) ||
        index > confStep + 1 ||
        confIsPending ||
        (isEditMode && index === 0)
      }
      key={keyGen.getKey(step)}
      onClick={() => handleStepChange(index)}
      className={`btn btn-tertiary alt ${confStep === index ? 'active' : ''}`}
    >
      {confValidated[index] && <i className="fas fa-circle-check" />}
      {!confValidated[index] && <i className={`far fa-circle-${index + 1}`} />}
      {step}
    </button>
  ))}
</div>
```